### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,8 @@
     "@types/axios": "^0.14.4",
     "axios": "^1.8.1",
     "dotenv": "^16.4.1",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "sanitize-html": "^2.14.0"
   },
   "repository": {
     "type": "git",

--- a/src/utils/responseParser.ts
+++ b/src/utils/responseParser.ts
@@ -1,5 +1,6 @@
 import { CommitMessage } from "../config/types";
 import { debugLog } from "../services/debug/logger";
+import sanitizeHtml from 'sanitize-html';
 
 export function parseMarkdownContent(content: string): CommitMessage {
     const summaryMatch = content.match(/# Commit Summary\s*\n([^\n#]*)/);
@@ -27,11 +28,21 @@ export function cleanDeepSeekResponse(response: string): string {
         }
     }
 
-    return response
-        .replace(/<think>[\s\S]*?<\/think>/g, '')
-        .replace(/<[^>]*>/g, '')
-        .replace(/\s+/g, ' ')
-        .trim();
+    let previous;
+    do {
+        previous = response;
+        response = response
+            .replace(/<think>[\s\S]*?<\/think>/g, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    } while (response !== previous);
+
+    response = sanitizeHtml(response, {
+        allowedTags: [],
+        allowedAttributes: {}
+    });
+
+    return response;
 }
 
 export function cleanGeminiResponse(response: string): string {


### PR DESCRIPTION
Potential fix for [https://github.com/shahabahreini/AI-Commit-Assistant/security/code-scanning/2](https://github.com/shahabahreini/AI-Commit-Assistant/security/code-scanning/2)

To fix the problem, we will apply the regular expression replacements repeatedly until no more replacements can be performed. This ensures that all instances of the targeted patterns are removed from the input. Additionally, we will use a well-tested sanitization library, `sanitize-html`, to handle HTML tag removal more effectively.

1. Modify the `cleanDeepSeekResponse` function to apply the regular expression replacements in a loop until no more replacements can be performed.
2. Use the `sanitize-html` library to handle HTML tag removal in the `cleanDeepSeekResponse` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
