### PR TITLE
fix: repair Wiki publishing workflow validation

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -27,13 +27,14 @@ jobs:
     name: Validate Wiki
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: node scripts/validate-wiki.mjs
       - name: Validate issue forms and workflow YAML
-        run: ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.{yml,yaml}", ".github/workflows/*.{yml,yaml}"].each { |file| YAML.load_file(file); puts "valid #{file}" }'
+        run: |
+          ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.{yml,yaml}", ".github/workflows/*.{yml,yaml}"].each { |file| YAML.load_file(file); puts "valid #{file}" }'
 
   publish:
     name: Publish Wiki
@@ -41,7 +42,7 @@ jobs:
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Require Wiki push token
         env:
           WIKI_PUSH_TOKEN: ${{ secrets.WIKI_PUSH_TOKEN }}


### PR DESCRIPTION
## Fixes
- prevent YAML from truncating the Ruby validation command at `#{file}`
- update GitHub actions to Node 24-compatible `checkout@v6` and `setup-node@v6`
- run Wiki validation with Node.js 24

## Validation
- `npm run validate:wiki`
- exact Ruby issue-form/workflow YAML validation command
- `git diff --check`